### PR TITLE
Re-build of libiconv 1.16 for all architectures

### DIFF
--- a/recipe/CMakeLists.txt.patch
+++ b/recipe/CMakeLists.txt.patch
@@ -51,7 +51,7 @@
 +# libiconv
 +set ( SRC_LIBICONV
 +  lib/iconv.c
-+  lib/relocatable-stub.c
++  lib/relocatable.c
 +)
 +
 +add_library ( iconv SHARED ${SRC_LIBICONV} )

--- a/recipe/CMakeLists.txt.patch
+++ b/recipe/CMakeLists.txt.patch
@@ -41,7 +41,7 @@
 +# libcharset
 +set ( SRC_LIBCHARSET
 +  libcharset/lib/localcharset.c
-+  libcharset/lib/relocatable.c
++  libcharset/lib/relocatable-stub.c
 +)
 +
 +add_library ( charset SHARED ${SRC_LIBCHARSET} )

--- a/recipe/CMakeLists.txt.patch
+++ b/recipe/CMakeLists.txt.patch
@@ -41,7 +41,7 @@
 +# libcharset
 +set ( SRC_LIBCHARSET
 +  libcharset/lib/localcharset.c
-+  libcharset/lib/relocatable-stub.c
++#  libcharset/lib/relocatable-stub.c
 +)
 +
 +add_library ( charset SHARED ${SRC_LIBCHARSET} )

--- a/recipe/CMakeLists.txt.patch
+++ b/recipe/CMakeLists.txt.patch
@@ -51,7 +51,7 @@
 +# libiconv
 +set ( SRC_LIBICONV
 +  lib/iconv.c
-+  lib/relocatable.c
++  lib/relocatable-stub.c
 +)
 +
 +add_library ( iconv SHARED ${SRC_LIBICONV} )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,9 @@ make install
 if [[ ${HOST} =~ .*linux.* ]]; then
   chmod 755 ${PREFIX}/lib/libiconv.so.*
   chmod 755 ${PREFIX}/lib/libcharset.so.*
-  chmod 755 ${PREFIX}/lib/preloadable_libiconv.so
+  if [ -f ${PREFIX}/lib/preloadable_libiconv.so ]; then
+    chmod 755 ${PREFIX}/lib/preloadable_libiconv.so
+  fi
 fi
 
 # remove libtool files

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - configure.cmake.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # Pretty good recently, let's trust them.
     #   https://abi-laboratory.pro/tracker/timeline/libiconv/
@@ -45,8 +45,8 @@ about:
   description: |
     This library provides an iconv() implementation, for use on systems which don't have one,
     or whose implementation cannot convert from/to Unicode.
-  doc_url: https://www.gnu.org/savannah-checkouts/gnu/libiconv/documentation/libiconv-1.15/iconv.1.html
-  dev_url: http://git.savannah.gnu.org/cgit/libiconv.git/tree/
+  doc_url: https://www.gnu.org/savannah-checkouts/gnu/libiconv/documentation/libiconv-{{ version }}/iconv.1.html
+  dev_url: http://git.savannah.gnu.org/cgit/libiconv.git/tag/?h=v{{ version }}
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  - url: http://ftp.gnu.org/pub/gnu/libiconv/libiconv-{{ version }}.tar.gz
+  - url: https://ftp.gnu.org/pub/gnu/libiconv/libiconv-{{ version }}.tar.gz
     sha256: e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
     patches:
       - glibc.patch  # [linux]
@@ -42,13 +42,14 @@ about:
   license_file: 
     - COPYING
     - COPYING.LIB
+  license_family: GPL3
   summary: "Provides iconv for systems which don't have one (or that cannot convert from/to Unicode.)"
 
   description: |
     This library provides an iconv() implementation, for use on systems which don't have one,
     or whose implementation cannot convert from/to Unicode.
   doc_url: https://www.gnu.org/savannah-checkouts/gnu/libiconv/documentation/libiconv-{{ version }}/iconv.1.html
-  dev_url: http://git.savannah.gnu.org/cgit/libiconv.git/tree/
+  dev_url: https://git.savannah.gnu.org/cgit/libiconv.git/tree/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,15 +38,17 @@ test:
 
 about:
   home: https://www.gnu.org/software/libiconv/
-  license: GPL and LGPL
-  license_file: COPYING
+  license: GPL-3.0-or-later
+  license_file: 
+    - COPYING
+    - COPYING.LIB
   summary: "Provides iconv for systems which don't have one (or that cannot convert from/to Unicode.)"
 
   description: |
     This library provides an iconv() implementation, for use on systems which don't have one,
     or whose implementation cannot convert from/to Unicode.
   doc_url: https://www.gnu.org/savannah-checkouts/gnu/libiconv/documentation/libiconv-{{ version }}/iconv.1.html
-  dev_url: http://git.savannah.gnu.org/cgit/libiconv.git/tag/?h=v{{ version }}
+  dev_url: http://git.savannah.gnu.org/cgit/libiconv.git/tree/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# Changes

Changes:
- Update metadata dev_url and doc_url to point to specific version
- Increment build number (as this was already built for some archs)
- Make chmod of preloadable_libiconv.so optional, as this is not built on 1.16 when enable-static is set.
- Update CMake conf (used for windows only) to not use source relocatable.c, to follow changes on 1.16.

# Review Information

## Source

http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz

## License

https://git.savannah.gnu.org/gitweb/?p=libiconv.git;a=blob;f=COPYING;h=94a9ed024d3859793618152ea559a168bbcbb5e2;hb=151d0122cf531005569adecedf0d27107e00a138

## Upstream Changes

https://git.savannah.gnu.org/gitweb/?p=libiconv.git;a=blob;f=ChangeLog;h=8a3b55492f4d6ec7f7ad3b8233694059cb5e0a53;hb=151d0122cf531005569adecedf0d27107e00a138

## Issues

Bug reports should be sent to [<bug-gnu-libiconv@gnu.org>](mailto:bug-gnu-libiconv-antispam@gnu.org).

## Pins and Requireds

NA

## Testing

Existing tests passed.


# Closing Comments

libiconv build to 1.16 on all architectures

Checking at other recipes: 
- only rsync-feedstock sets libiconv as a host requirement for linux, but there are no rsync package in the default channel, for any architecture.
- some recipes restrict libiconv to osx only, some to win only, and others to osx and win only.

# Jira

https://anaconda.atlassian.net/browse/DSNC-4681